### PR TITLE
Check for the presense of body in the raw_response before casting to string

### DIFF
--- a/lib/motion/oauth2/response.rb
+++ b/lib/motion/oauth2/response.rb
@@ -52,7 +52,7 @@ module Motion
       end
 
       def body
-        raw_response.body.to_str
+        raw_response.body.to_str unless raw_response.body.nil?
       end
 
       def json


### PR DESCRIPTION
A possible http status code is status 204 which is success without any content. The gem does not handle this well since it blindly tries to cast the body to a string. I wrote a check for the body's presence before casting it to string.
